### PR TITLE
fix(basic-sample): update include to resolve deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ tags
 _site
 .jekyll-cache
 vendor
+
+.DS_Store
+.vscode/
+.history/

--- a/docs/1-zephyr-setup/install/linux.md
+++ b/docs/1-zephyr-setup/install/linux.md
@@ -84,7 +84,7 @@ $ west build -p always -b esp32 samples/hello_world/
 The `-p` option does a pristine build. It is used to build when there is any changes done to the CMake.
 
 A successful build looks like this
-![success_build_hello_world](/images/1-zephyr-setup/hello_world_build_success.png)
+![success_build_hello_world](../../images/1-zephyr-setup/hello_world_build_success.png)
 Now flash the board with
 ```
 $ west flash
@@ -94,7 +94,7 @@ To open the serial monitor
 $ west espressif monitor
 ```
 You should see the similar output
-![hello_world_success_output](/images/1-zephyr-setup/hello_world_output.png)
+![hello_world_success_output](../../images/1-zephyr-setup/hello_world_output.png)
 
 ## 4) Building the blinky
 Now, let's try to blink the builtin LED on ESP32. The sample is in `zephyr/samples/basic/blinky`
@@ -102,7 +102,7 @@ Now, let's try to blink the builtin LED on ESP32. The sample is in `zephyr/sampl
 $ west build -p -b esp32 samples/basic/blinky
 ```
 If you encounter build errors like this
-![blinky_build_error](/images/1-zephyr-setup/blinky_build_errors.png)
+![blinky_build_error](../../images/1-zephyr-setup/blinky_build_errors.png)
 It means that we need to add an overlay file with the board support. This file can be added for any unsupported board with the `<board-name>.overlay`. <br/>
 Create an `esp32.overlay` file in `zephyr/samples/basic/blinky/` and add the following contents
 ```dtc

--- a/docs/1-zephyr-setup/install/mac-os.md
+++ b/docs/1-zephyr-setup/install/mac-os.md
@@ -92,7 +92,7 @@ echo $ZEPHYR_TOOLCHAIN_VARIANT
 echo $GNUARMEMB_TOOLCHAIN_PATH
 ```
   
-![env_var_check](/images/1-zephyr-setup/env-var-check.png)
+![env_var_check](../../images/1-zephyr-setup/env-var-check.png)
 
 ## 5) Build the Blinky sample
 
@@ -103,7 +103,7 @@ cd ~/zephyrproject/zephyr/samples/basic/blinky
 west build -b <board-name>  # for example: nucleo_l552ze_q
 ```
 A successful build looks like this:
-![succes_build](/images/1-zephyr-setup/success-build.png)
+![succes_build](../../images/1-zephyr-setup/success-build.png)
 
 {: .note }
 > If you get a CMake error, this can usually be resolved by clearing the previous build: `rm -rf build`
@@ -115,7 +115,7 @@ west flash
 ```
 A successful flash looks like this:
 
-![succes_flash](/images/1-zephyr-setup/success-flash.png)
+![succes_flash](../../images/1-zephyr-setup/success-flash.png)
 
 {: .warning}
 > Some boards will require installing an additional `pyocd` package! 

--- a/docs/1-zephyr-setup/setup/mac-os.md
+++ b/docs/1-zephyr-setup/setup/mac-os.md
@@ -60,6 +60,7 @@ west flash
 
 {: .note }
 > If you've previously made a build for a different board, remove the old build first: `rm -rf build`
+> For convenience, full path to the basic-sample page: `cd ~/zephyrproject/zephyr-rtos-tutorial/exercises/basic-sample`
 
 - Verify the serial output:
 

--- a/docs/1-zephyr-setup/setup/mac-os.md
+++ b/docs/1-zephyr-setup/setup/mac-os.md
@@ -18,19 +18,19 @@ nav_order: 1
     - Port: `usbmodemxxxxx`
     - Baudrate: `115200`
 
-![coolterm-1](/images/1-zephyr-setup/coolterm-1.png)
+![coolterm-1](../../images/1-zephyr-setup/coolterm-1.png)
 
 - `Terminal`: check "Filter ASCII Escape Sequences" and press `Ok`
 
-![coolterm-2](/images/1-zephyr-setup/coolterm-2.png)
+![coolterm-2](../../images/1-zephyr-setup/coolterm-2.png)
 
 - `File -> Save`: Save this configuration under `~/zephyrproject`
 
-![coolterm-settings](/images/1-zephyr-setup/coolterm-settings.png)
+![coolterm-settings](../../images/1-zephyr-setup/coolterm-settings.png)
 
 - `Connect`
   
-![coolterm-connect](/images/1-zephyr-setup/coolterm-connect.png)
+![coolterm-connect](../../images/1-zephyr-setup/coolterm-connect.png)
 
 ## 2) VSCode
 
@@ -64,8 +64,8 @@ west flash
 
 - Verify the serial output:
 
-![coolterm-3](/images/1-zephyr-setup/coolterm-3.png)
+![coolterm-3](../../images/1-zephyr-setup/coolterm-3.png)
 
 Your final setup should look something like this:
 
-![final-setup](/images/1-zephyr-setup/final-setup.png)
+![final-setup](../../images/1-zephyr-setup/final-setup.png)

--- a/docs/2-introduction/zephyr-structure.md
+++ b/docs/2-introduction/zephyr-structure.md
@@ -11,7 +11,7 @@ nav_order: 10
 
 Before we start writing our first applications in Zephyr, it might be a good step to take a look at the folder structure that Zephyr provides us.
 
-![sample-folder](/images/2-introduction/sample-folder.png)
+![sample-folder](../../images/2-introduction/sample-folder.png)
 
 Let's go one-by-one:
 

--- a/docs/2-introduction/zephyr-structure.md
+++ b/docs/2-introduction/zephyr-structure.md
@@ -28,7 +28,7 @@ This file will be used by [CMake](https://en.wikipedia.org/wiki/CMake) to set up
 ### prj.conf
 This is you Kconfig file. **Important!** This file will contain any *additional* settings you want set for your particular Zephyr build. Depending on your particular application, you might want to (for example) include a TCP/IP stack or make some changes to the scheduler. We'll explore some of these options throughout the tutorial.
 
-![k-config](/images/2-introduction/k-config.png)
+![k-config](../../images/2-introduction/k-config.png)
 
 Right now it's pretty empty, since for `basic-sample` we don't require any "fancy" functionality, just the basic Zephyr kernel. The only additional functionality we set is `CONFIG_PRINTK`, which allows us to use the `printk` function to output to the serial port (which is then displayed on your computer screen using Coolterm).
 
@@ -36,9 +36,9 @@ If you're ever unsure about what a particular config setting does, you have 2 op
 - Use [google](https://www.google.com/search?client=firefox-b-d&q=zephyr+CONFIG_PRINTK): usually Zephyr Documentation is one of the first links
 - Use the `guiconfig`: in your `basic-sample` folder execute `west build -t guiconfig`. This will show you a menu of all the possible configuration settings and a small description of what each one does. (Use `Jump to` to find a particular config)
   
-![guiconfig](/images/2-introduction/guiconfig.png)
+![guiconfig](../../images/2-introduction/guiconfig.png)
 
 ### src
 Where the magic happens! This folder should contain all of your custom application code. For now it contains one file: `main.c`, which prints out a message to the serial port and then sleeps for 1 second.
 
-![basic-sample](/images/2-introduction/basic-sample.png)
+![basic-sample](../../images/2-introduction/basic-sample.png)

--- a/docs/3-threads/commands.md
+++ b/docs/3-threads/commands.md
@@ -67,22 +67,22 @@ K_THREAD_DEFINE(my_tid, MY_STACK_SIZE,
 ### k_thread_start()
 A thread must be created before it can be used.
 
-![k_thread_im](/svg-images/threads/thread-start.png)
+![k_thread_im](../../svg-images/threads/thread-start.png)
 
 ### k_thread_abort()
 Abort a thread. Thread is taken off all kernel queues.
 
-![k_thread_im](/svg-images/threads/thread-abort.png)
+![k_thread_im](../../svg-images/threads/thread-abort.png)
 
 ### k_sleep()
 A thread can prevent itself from executing for a specified amount of time. A sleeping thread becomes executable automatically once the time limit is reached.
 
-![k_thread_im](/svg-images/threads/thread-sleep.png)
+![k_thread_im](../../svg-images/threads/thread-sleep.png)
 
 ### k_thread_suspend()
 Prevent a thread from executing for an indefinite period of time. Once suspended, use k_thread_resume() to re-start.
 
-![k_thread_im](/svg-images/threads/thread-suspend.png)
+![k_thread_im](../../svg-images/threads/thread-suspend.png)
 
 ### k_thread_join()
 Sleep until a thread exits. 
@@ -92,6 +92,6 @@ For example:
 - thread_a is responsible for processing data from this interface
 - As long as thread_b has not exited, thread_a can't start, so we'll use k_thread_join(thread_b, timeout) in this case.
 
-![k_thread_im](/svg-images/threads/thread-join.png)
+![k_thread_im](../../svg-images/threads/thread-join.png)
 
 

--- a/docs/3-threads/exercise.md
+++ b/docs/3-threads/exercise.md
@@ -36,11 +36,11 @@ For solving the exercises I recommend you create your own folder inside `zephyr-
 - Use `k_thread_create()` to create a thread
 - Implement the following
 
-![thread-start](/svg-images/threads/thread-start.png)
+![thread-start](../../svg-images/threads/thread-start.png)
 
 - Output the following serial using `printk()`
 
-![thread-start](/images/threads/thread-start.png)
+![thread-start](../../images/threads/thread-start.png)
 
 solution: `exercises/threads/thread-start`
 
@@ -54,11 +54,11 @@ solution: `exercises/threads/thread-start-define`
 
 - Implement the following
 
-![thread-abort](/svg-images/threads/thread-abort.png)
+![thread-abort](../../svg-images/threads/thread-abort.png)
 
 - Output the following serial using `printk()`
 
-![thread-abort](/images/threads/thread-abort.png)
+![thread-abort](../../images/threads/thread-abort.png)
 
 solution: `exercises/threads/thread-abort`
 
@@ -66,11 +66,11 @@ solution: `exercises/threads/thread-abort`
 
 - Implement the following
 
-![thread-sleep](/svg-images/threads/thread-sleep.png)
+![thread-sleep](../../svg-images/threads/thread-sleep.png)
 
 - Output the following serial using `printk()`
 
-![thread-sleep](/images/threads/thread-sleep.png)
+![thread-sleep](../../images/threads/thread-sleep.png)
 
 solution: `exercises/threads/thread-sleep`
 
@@ -78,11 +78,11 @@ solution: `exercises/threads/thread-sleep`
 
 - Implement the following
 
-![thread-sleep](/svg-images/threads/thread-suspend.png)
+![thread-sleep](../../svg-images/threads/thread-suspend.png)
 
 - Output the following serial using `printk()`
 
-![thread-sleep](/images/threads/thread-suspend.png)
+![thread-sleep](../../images/threads/thread-suspend.png)
 
 solution: `exercises/threads/thread-suspend`
 
@@ -90,10 +90,10 @@ solution: `exercises/threads/thread-suspend`
 
 - Implement the following
 
-![thread-join](/svg-images/threads/thread-join.png)
+![thread-join](../../svg-images/threads/thread-join.png)
 
 - Output the following serial using `printk()`
 
-![thread-join](/images/threads/thread-join.png)
+![thread-join](../../images/threads/thread-join.png)
 
 solution: `exercises/threads/thread-join`

--- a/docs/3-threads/introduction.md
+++ b/docs/3-threads/introduction.md
@@ -11,15 +11,15 @@ A thread is an isolated instance that is responsible for the execution of some t
  Some key concepts:
 - **Stack area**: a region of memory used for the thread's stack. The size can be adjusted as required by the thread's processing.
 
-![thread-stack-size](/images/threads/thread-stack-size.png)
+![thread-stack-size](../../images/threads/thread-stack-size.png)
 
 - **Thread control block**: for internal bookkeeping of the thread's metadata. An instance of the type `k_thread`.
 
-![thread-control-block](/images/threads/thread-control-block.png)
+![thread-control-block](../../images/threads/thread-control-block.png)
 
 - **Entry point function**: invoked when the thread is started. Up to 3 argument values can be passed to this function.
 
-![thread-entry-point](/images/threads/thread-entry-point.png)
+![thread-entry-point](../../images/threads/thread-entry-point.png)
 
 _ARG_UNUSED is needed to indicate that the 3 arguments are not used in our thread function._
 
@@ -41,4 +41,4 @@ Following factors can make a thread unready:
 
 The following diagram shows all the possible states a thread can find itself:
 
-![thread_states](/images/threads/thread-states.png)
+![thread_states](../../images/threads/thread-states.png)

--- a/docs/4-gpio/introduction.md
+++ b/docs/4-gpio/introduction.md
@@ -20,7 +20,7 @@ When setting up any GPIO the following basic steps have to be followed:
 The devicetree for your particular build can be found at `build/zephyr/zephyr.dts` or for each board in `zephyrproject/zephyr/boards`
 
 For example, the red arrow indicates the device binding to toggle the green led.
-![devicetree-binding](/images/gpio/devicetree-binding.png)
+![devicetree-binding](../../images/gpio/devicetree-binding.png)
 
 2) To use the device binding in our main.c file; we need to use the following defines:
 

--- a/docs/5-scheduling/exercise.md
+++ b/docs/5-scheduling/exercise.md
@@ -12,7 +12,7 @@ Implement cooperative time slicing that puts out the following serial output (us
 
 *figure showing that thread_1, even though lower priority, doesn't yield to thread_2 (until finished)*
 
-![serial-coop-time-slicing](/images/scheduling/serial-coop-time-slicing.png)
+![serial-coop-time-slicing](../../images/scheduling/serial-coop-time-slicing.png)
 
 
 ## Preemptive Time Slicing
@@ -21,7 +21,7 @@ Implement Preemptive time slicing that puts out the serial (using `printk()`)
 
 *figure showing the increase in thread priority and preemption and completion of each thread*
 
-![serial-preemptive-time-slicing](/images/scheduling/serial-preemptive-time-slicing.png)
+![serial-preemptive-time-slicing](../../images/scheduling/serial-preemptive-time-slicing.png)
 
 ## Time Slicing (with 3 threads)
 
@@ -29,4 +29,4 @@ Implement time slicing with three threads (of equal priority)
 
 *figure showing the equal priority threads preempting each other*
 
-![serial-time-slicing](/images/scheduling/serial-time-slicing.png)
+![serial-time-slicing](../../images/scheduling/serial-time-slicing.png)

--- a/docs/5-scheduling/introduction.md
+++ b/docs/5-scheduling/introduction.md
@@ -77,7 +77,7 @@ The kernel supports a virtually unlimited number of thread priority levels. The 
 
 Once a cooperative thread becomes the current thread, it remains the current thread until it performs an action that makes it unready. Consequently, if a cooperative thread performs lengthy computations, it may cause an unacceptable delay in the scheduling of other threads, including those of higher priority.
 
-![cooperative](/images/scheduling/cooperative.png)
+![cooperative](../../images/scheduling/cooperative.png)
 
 To overcome such problems, a cooperative thread can voluntarily relinquish the CPU from time to time to permit other threads to execute. A thread can relinquish the CPU in two ways:
 - Calling k_yield() puts the thread at the back of the scheduler's prioritized list of ready threads, and then invokes the scheduler. All ready threads whose priority is higher or equal to that of the yielding thread are then allowed to execute before the yielding thread is rescheduled. If no such threads exist, the scheduler immediately reschedules the yielding thread without context switching. 
@@ -87,11 +87,11 @@ To overcome such problems, a cooperative thread can voluntarily relinquish the C
 
 Once a preemptive thread becomes the current thread, it remains the current thread until a higher priority thread becomes ready, or until the thread performs an action that makes it unready. Consequently, if a preemptive thread performs lengthy computations, it may cause an unacceptable delay in the scheduling of other threads, including those of equal priority. 
 
-![preemptive](/images/scheduling/preemptive.png)
+![preemptive](../../images/scheduling/preemptive.png)
 
 To overcome such problems, a preemptive thread can perform cooperative time slicing (as described above), or the scheduler's time slicing capability can be used to allow other threads of the same priority to execute.
 
-![timeslicing](/images/scheduling/timeslicing.png)
+![timeslicing](../../images/scheduling/timeslicing.png)
 
 The scheduler divides time into a series of time slices, where slices are measured in system clock ticks. The time slice size is configurable, but this size can be changed while the application is running.
 

--- a/docs/7-debugging/exercise.md
+++ b/docs/7-debugging/exercise.md
@@ -40,11 +40,11 @@ The svd file can be found on the [STM](https://www.st.com/en/microcontrollers-mi
 
 *The first screen should look like this:*
 
-![debug-starting](/images/debugging/debug-starting.png)
+![debug-starting](../../images/debugging/debug-starting.png)
 
 *If you put an interrupt in the first interrupt, the execution will again be stopped at this point*
 
-![debug-breakpoint](/images/debugging/debug-breakpoint-1.png)
+![debug-breakpoint](../../images/debugging/debug-breakpoint-1.png)
 
 Notice the "Cortex Peripherals" and "Cortex Registers" on the left-hand side.
 
@@ -61,7 +61,7 @@ west flash
 
 3) Observe the output in the serial monitor:
 
-![runtime-statistics](/images/debugging/runtime-statistics.png)
+![runtime-statistics](../../images/debugging/runtime-statistics.png)
 
 ## Exercise 3: Core dump
 

--- a/docs/7-debugging/introduction.md
+++ b/docs/7-debugging/introduction.md
@@ -22,7 +22,7 @@ To enable thread-aware debugging you'll need to add the line shown below to `zep
 $_TARGETNAME configure -rtos Zephyr
 ```
 
-![openocd-threads-support](/images/debugging/openocd-threads-support.png)
+![openocd-threads-support](../../images/debugging/openocd-threads-support.png)
 
 A debug probe is special hardware which allows you to control execution of a Zephyr application running on a separate board. Debug probes usually allow reading and writing registers and memory, and support breakpoint debugging of the Zephyr application on your host workstation using tools like GDB. 
 

--- a/docs/8-interrupts/exercise.md
+++ b/docs/8-interrupts/exercise.md
@@ -21,8 +21,8 @@ on button press: print out "isr message"
 
 User button and LED aliases can be found in the devicetree file `build/zephyr/zephyr.dts`.
 
-![button-interrupt-alias](/images/interrupts/button-interrupt-alias.png)
+![button-interrupt-alias](../../images/interrupts/button-interrupt-alias.png)
 
 Expected output:
 
-![button-interrupt-output](/images/interrupts/button-interrupt-output.png)
+![button-interrupt-output](../../images/interrupts/button-interrupt-output.png)

--- a/exercises/basic-sample/src/main.c
+++ b/exercises/basic-sample/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 


### PR DESCRIPTION
Replaced `<zephyr/zephyr.h>` with `<zephyr/kernel.h>` based on the following compilation warning raised:

	#warning "<zephyr/zephyr.h> is deprecated, include <zephyr/kernel.h> instead" [-Wcpp]

Note: This change has been applied to the basic-sample only. Most likely other samples in the project might require the same update.